### PR TITLE
 Twilio Video Android 3.2.2.0 binding 

### DIFF
--- a/sample/Twilio.Video.Sample.Android/Twilio.Video.Sample.Android.csproj
+++ b/sample/Twilio.Video.Sample.Android/Twilio.Video.Sample.Android.csproj
@@ -16,8 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
@@ -181,7 +180,7 @@
     <AndroidResource Include="Resources\values-w820dp\dimens.xml" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\source\Twilio.Video.Android\v2\Twilio.Video.Android.csproj">
+    <ProjectReference Include="..\..\source\Twilio.Video.Android\v3\Twilio.Video.Android.csproj">
       <Project>{72204651-f86d-4e85-9eb3-92e5db4d1c0d}</Project>
       <Name>Twilio.Video.Android</Name>
     </ProjectReference>

--- a/source/Twilio.Video.Android/v3/Additions/AboutAdditions.txt
+++ b/source/Twilio.Video.Android/v3/Additions/AboutAdditions.txt
@@ -1,0 +1,48 @@
+﻿Additions allow you to add arbitrary C# to the generated classes
+before they are compiled.  This can be helpful for providing convenience
+methods or adding pure C# classes.
+
+== Adding Methods to Generated Classes ==
+
+Let's say the library being bound has a Rectangle class with a constructor
+that takes an x and y position, and a width and length size.  It will look like
+this:
+
+public partial class Rectangle
+{
+    public Rectangle (int x, int y, int width, int height)
+    {
+        // JNI bindings
+    }
+}
+
+Imagine we want to add a constructor to this class that takes a Point and
+Size structure instead of 4 ints.  We can add a new file called Rectangle.cs
+with a partial class containing our new method:
+
+public partial class Rectangle
+{
+    public Rectangle (Point location, Size size) :
+        this (location.X, location.Y, size.Width, size.Height)
+    {
+    }
+}
+
+At compile time, the additions class will be added to the generated class
+and the final assembly will a Rectangle class with both constructors.
+
+
+== Adding C# Classes ==
+
+Another thing that can be done is adding fully C# managed classes to the
+generated library.  In the above example, let's assume that there isn't a
+Point class available in Java or our library.  The one we create doesn't need
+to interact with Java, so we'll create it like a normal class in C#.
+
+By adding a Point.cs file with this class, it will end up in the binding library:
+
+public class Point
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+}

--- a/source/Twilio.Video.Android/v3/Jars/AboutJars.txt
+++ b/source/Twilio.Video.Android/v3/Jars/AboutJars.txt
@@ -1,0 +1,24 @@
+﻿This directory is for Android .jars.
+
+There are 2 types of jars that are supported:
+
+== Input Jar ==
+
+This is the jar that bindings should be generated for.
+
+For example, if you were binding the Google Maps library, this would
+be Google's "maps.jar".
+
+Set the build action for these jars in the properties page to "InputJar".
+
+
+== Reference Jars ==
+
+These are jars that are referenced by the input jar.  C# bindings will
+not be created for these jars.  These jars will be used to resolve
+types used by the input jar.
+
+NOTE: Do not add "android.jar" as a reference jar.  It will be added automatically
+based on the Target Framework selected.
+
+Set the build action for these jars in the properties page to "ReferenceJar".

--- a/source/Twilio.Video.Android/v3/Properties/AssemblyInfo.cs
+++ b/source/Twilio.Video.Android/v3/Properties/AssemblyInfo.cs
@@ -1,0 +1,30 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Android.App;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Twilio.Video.Android")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Twilio.Video.Android")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/source/Twilio.Video.Android/v3/Transforms/EnumFields.xml
+++ b/source/Twilio.Video.Android/v3/Transforms/EnumFields.xml
@@ -1,0 +1,6 @@
+﻿<enum-field-mappings>
+  <mapping jni-class="com/twilio/video/VideoPixelFormat" clr-enum-type="Com.Twilio.Video.PixelFormat">
+    <field jni-name="NV21" clr-name="Nv21" value="0" />
+    <field jni-name="RGBA_8888" clr-name="Rgba8888" value="1" />
+  </mapping>
+</enum-field-mappings>

--- a/source/Twilio.Video.Android/v3/Transforms/EnumMethods.xml
+++ b/source/Twilio.Video.Android/v3/Transforms/EnumMethods.xml
@@ -1,0 +1,13 @@
+﻿<enum-method-mappings>
+  <!--
+  This example changes the Java method:
+    android.support.v4.app.Fragment.SavedState.writeToParcel (int flags)
+  to be:
+    android.support.v4.app.Fragment.SavedState.writeToParcel (Android.OS.ParcelableWriteFlags flags)
+  when bound in C#.
+  
+  <mapping jni-class="android/support/v4/app/Fragment.SavedState">
+    <method jni-name="writeToParcel" parameter="flags" clr-enum-type="Android.OS.ParcelableWriteFlags" />
+  </mapping>
+  -->
+</enum-method-mappings>

--- a/source/Twilio.Video.Android/v3/Transforms/Metadata.xml
+++ b/source/Twilio.Video.Android/v3/Transforms/Metadata.xml
@@ -1,0 +1,29 @@
+﻿<metadata>
+  <attr path="/api/package[@name='com.twilio.video']" name="managedName">TwilioVideo</attr>
+
+  <attr path="/api/package[@name='org.webrtc']/class[@name='StatsReport.Value']" name="managedName">StatsReportValue</attr>
+
+  <attr path="/api/package[@name='org.webrtc']/interface[@name='CameraSession']" name="visibility">public</attr>
+
+  <remove-node path="/api/package[@name='org.webrtc']/class[@name='Camera1Capturer']/method[@name='getCameraSession' and count(parameter)=0]"/>
+
+  <attr path="/api/package[@name='com.twilio.video']/
+        interface[@name='RemoteDataTrack.Listener']/
+        method[@name='onMessage' and count(parameter)=2 and parameter[1][@type='com.twilio.video.RemoteDataTrack'] and parameter[2][@type='java.lang.String']]"
+        name="argsType">Message1EventArgs</attr>
+
+  <attr path="/api/package[@name='com.twilio.video']/
+        interface[@name='RemoteDataTrack.Listener']/
+        method[@name='onMessage' and count(parameter)=2 and parameter[1][@type='com.twilio.video.RemoteDataTrack'] and parameter[2][@type='java.nio.ByteBuffer']]"
+      name="argsType">Message2EventArgs</attr>
+
+  <attr path="/api/package[@name='com.twilio.video']/
+        interface[@name='RemoteDataTrack.Listener']/
+        method[@name='onMessage' and count(parameter)=2 and parameter[1][@type='com.twilio.video.RemoteDataTrack'] and parameter[2][@type='java.lang.String']]"
+      name="managedName">OnMessage1</attr>
+
+  <attr path="/api/package[@name='com.twilio.video']/
+        interface[@name='RemoteDataTrack.Listener']/
+        method[@name='onMessage' and count(parameter)=2 and parameter[1][@type='com.twilio.video.RemoteDataTrack'] and parameter[2][@type='java.nio.ByteBuffer']]"
+      name="managedName">OnMessage2</attr>
+</metadata>

--- a/source/Twilio.Video.Android/v3/Twilio.Video.Android.csproj
+++ b/source/Twilio.Video.Android/v3/Twilio.Video.Android.csproj
@@ -5,7 +5,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{B13F78F8-E942-480E-8920-BC81ED81B042}</ProjectGuid>
+    <ProjectGuid>{72204651-F86D-4E85-9EB3-92E5DB4D1C0D}</ProjectGuid>
     <ProjectTypeGuids>{10368E6C-D01B-4462-8E8B-01FC667A7035};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TemplateGuid>{77efb91c-a7e9-4b0e-a7c5-31eeec3c6d46}</TemplateGuid>
     <OutputType>Library</OutputType>

--- a/source/Twilio.Video.Android/v3/Twilio.Video.Android.csproj
+++ b/source/Twilio.Video.Android/v3/Twilio.Video.Android.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{B13F78F8-E942-480E-8920-BC81ED81B042}</ProjectGuid>
+    <ProjectTypeGuids>{10368E6C-D01B-4462-8E8B-01FC667A7035};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TemplateGuid>{77efb91c-a7e9-4b0e-a7c5-31eeec3c6d46}</TemplateGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Twilio.Video.Android</RootNamespace>
+    <AssemblyName>Twilio.Video.Android</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <AndroidClassParser>class-parse</AndroidClassParser>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(Configuration.Contains('Release'))">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PackOnBuild>true</PackOnBuild>
+    <PackageId>Twilio.Video.Android.XamarinBinding</PackageId>
+    <PackageVersion>3.2.2.0</PackageVersion>
+    <Authors>twilio dkornev</Authors>
+    <Owners>twilio</Owners>
+    <PackageProjectUrl>https://github.com/dkornev/TwilioXamarinBindings</PackageProjectUrl>
+    <Summary>Twilio Video Android SDK binding for Xamarin Android</Summary>
+    <Title>Twilio Video Android SDK</Title>
+    <Description>Twilio Video makes it easy for you to add multi-party video calling into your mobile applications quickly</Description>
+    <PackageTags>twilio xamarin</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Mono.Android" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Jars\AboutJars.txt" />
+    <None Include="Additions\AboutAdditions.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <TransformFile Include="Transforms\Metadata.xml" />
+    <TransformFile Include="Transforms\EnumFields.xml" />
+    <TransformFile Include="Transforms\EnumMethods.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <LibraryProjectZip Include="Jars\video-android-3.2.2.aar" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/source/Twilio.Video.Android/v3/Twilio.Video.Android.sln
+++ b/source/Twilio.Video.Android/v3/Twilio.Video.Android.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.168
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Twilio.Video.Android", "Twilio.Video.Android.csproj", "{72204651-F86D-4E85-9EB3-92E5DB4D1C0D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{72204651-F86D-4E85-9EB3-92E5DB4D1C0D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72204651-F86D-4E85-9EB3-92E5DB4D1C0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72204651-F86D-4E85-9EB3-92E5DB4D1C0D}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{72204651-F86D-4E85-9EB3-92E5DB4D1C0D}.Release|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5918173B-841B-43E1-B6E7-779B1A1AB0B3}
+	EndGlobalSection
+EndGlobal

--- a/source/Twilio.Video.Android/v3/prograd.cfg
+++ b/source/Twilio.Video.Android/v3/prograd.cfg
@@ -1,0 +1,6 @@
+-keep class com.getkeepsafe.relinker.** { *; }
+-keep class org.webrtc.** { *; }
+-keep class com.twilio.video.** { *; }
+-keep class com.twilio.common.** { *; }
+-keep class twiliovideo.** { *; }
+-keepattributes InnerClasses


### PR DESCRIPTION
Fixes #2 

Twilio android-video v3 and its dependencies use Lambda expressions which are new Java 8 features.

The only way to be able to build a xamarin project containing the binding is by using Visual Studio 2019 Preview 2.2 (latest version at this date) and by adding `<AndroidDexTool>d8</AndroidDexTool>` into the csproj of your android project, one for each Debug/Release build.